### PR TITLE
Added apu-app dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "third-party/registers-generator"]
 	path = registers-generator
 	url = ../wd-nvme-registers-generator.git
+[submodule "third-party/spdlog"]
+	path = third-party/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,9 @@ buildroot//%: ## Forward rule to invoke Buildroot rules directly e.g. `make buil
 # -----------------------------------------------------------------------------
 
 REGGEN_REL_DIR=$(shell realpath --relative-to $(ROOT_DIR) $(REGGEN_DIR))
-DOCKER_BUILD_PYTHON_REQS_DIR=$(DOCKER_BUILD_DIR)/$(REGGEN_REL_DIR)
+APUAPP_REL_DIR=$(shell realpath --relative-to $(ROOT_DIR) $(APUAPP_DIR))
+DOCKER_BUILD_PYTHON_REQS_REGGEN_DIR=$(DOCKER_BUILD_DIR)/$(REGGEN_REL_DIR)
+DOCKER_BUILD_PYTHON_REQS_APUAPP_DIR=$(DOCKER_BUILD_DIR)/$(APUAPP_REL_DIR)
 
 
 $(DOCKER_BUILD_DIR):
@@ -310,8 +312,10 @@ docker: $(REGGEN_DIR)/requirements.txt
 docker: | $(DOCKER_BUILD_DIR)
 	cp $(ROOT_DIR)/fw.dockerfile $(DOCKER_BUILD_DIR)/Dockerfile
 	cp $(ROOT_DIR)/requirements.txt $(DOCKER_BUILD_DIR)/requirements.txt
-	mkdir -p $(DOCKER_BUILD_PYTHON_REQS_DIR)
-	cp $(REGGEN_DIR)/requirements.txt $(DOCKER_BUILD_PYTHON_REQS_DIR)/requirements.txt
+	mkdir -p $(DOCKER_BUILD_PYTHON_REQS_APUAPP_DIR)
+	mkdir -p $(DOCKER_BUILD_PYTHON_REQS_REGGEN_DIR)
+	cp $(REGGEN_DIR)/requirements.txt $(DOCKER_BUILD_PYTHON_REQS_REGGEN_DIR)/requirements.txt
+	cp $(APUAPP_DIR)/requirements.txt $(DOCKER_BUILD_PYTHON_REQS_APUAPP_DIR)/requirements.txt
 	cd $(DOCKER_BUILD_DIR) && docker build \
 		$(DOCKER_BUILD_EXTRA_ARGS) \
 		-t $(DOCKER_TAG) .

--- a/apu-app/requirements.txt
+++ b/apu-app/requirements.txt
@@ -1,6 +1,5 @@
-numpy==1.23.2
 onnx==1.12.0
 onnx_tf==1.10.0
 tensorflow==2.10.0
 torch==1.12.1
-tqdm==4.64.0
+tqdm==4.64.1

--- a/apu-app/requirements.txt
+++ b/apu-app/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.23.2
+onnx==1.12.0
+onnx_tf==1.10.0
+tensorflow==2.10.0
+torch==1.12.1
+tqdm==4.64.0

--- a/apu-app/requirements.txt
+++ b/apu-app/requirements.txt
@@ -1,5 +1,6 @@
 onnx==1.12.0
 onnx_tf==1.10.0
 tensorflow==2.10.0
+tensorflow_probability==0.18.0
 torch==1.12.1
 tqdm==4.64.1

--- a/br2-external/common/patches/uboot/0001-scripts-dtc-dtc-lexer.l-Fixed-extern-yylloc-to-suppo.patch
+++ b/br2-external/common/patches/uboot/0001-scripts-dtc-dtc-lexer.l-Fixed-extern-yylloc-to-suppo.patch
@@ -1,0 +1,33 @@
+From d12bf8db2e1138ac8551924b5535991ce81d90ca Mon Sep 17 00:00:00 2001
+From: Grzegorz Latosinski <glatosinski@antmicro.com>
+Date: Tue, 4 Oct 2022 13:43:18 +0200
+Subject: [PATCH] scripts: dtc: dtc-lexer.l: Fixed extern yylloc to support GCC
+ version 10
+
+The GCC 10 compiler was failing on multiple definitions of `yylloc`.
+This commit adds an `extern` specifier to the variable to resolve the
+issue.
+
+Internal-tag: [#37774]
+
+Signed-off-by: Grzegorz Latosinski <glatosinski@antmicro.com>
+---
+ scripts/dtc/dtc-lexer.l | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index fd825ebba6..f57c9a7e83 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.37.3
+

--- a/fw.dockerfile
+++ b/fw.dockerfile
@@ -43,8 +43,9 @@ RUN git clone -b v3.16.7 https://gitlab.kitware.com/cmake/cmake.git cmake && \
 # Install Python dependencies
 COPY requirements.txt requirements.txt
 COPY registers-generator/requirements.txt registers-generator/requirements.txt
+COPY apu-app/requirements.txt apu-app/requirements.txt
 RUN pip3 install -r requirements.txt
-RUN rm requirements.txt registers-generator/requirements.txt
+RUN rm requirements.txt registers-generator/requirements.txt apu-app/requirements.txt
 
 # Install Zephyr
 RUN wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.10.3/zephyr-sdk-0.10.3-setup.run && \

--- a/fw.dockerfile
+++ b/fw.dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM debian:buster
+FROM debian:bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies
@@ -31,10 +31,7 @@ RUN apt update -y && apt install -y \
   unzip \
   wget \
   u-boot-tools \
-  gcc-8
-
-# Use gcc-8 by default
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 9
+  gcc
 
 # Install CMake
 RUN git clone -b v3.16.7 https://gitlab.kitware.com/cmake/cmake.git cmake && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -r registers-generator/requirements.txt
+-r apu-app/requirements.txt
 west==0.13.1


### PR DESCRIPTION
The future PR introducing reimplementation of the VTA delegate introduces (among others) tests for delegated operations, such as ADD or CONV2D.

For those tests, models need to be generated - this PR:

* Adds `requirements.txt` file for `apu-app`,
* Bumps Docker image from `fw.dockerfile` to `debian:bullseye`
* Introduces fix to `uboot` package for buildroot, allowing to compile it with GCC >9
* Adjusts `fw.dockerfile` and `Makefile` to use new requirements.txt file,
* Adds `spdlog` for logging purposes in apu-app/rpu-app.