### PR TITLE
Fix CI running out of disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: antmicro/alkali:latest
+      volumes:
+        - /usr/share/dotnet:/usr/share/dotnet
+        - /usr/local/lib/android:/usr/local/lib/android
+        - /opt/ghc:/opt/ghc
     strategy:
       matrix:
         board: [an300, zcu106]
@@ -15,6 +19,15 @@ jobs:
       BOARD: ${{ matrix.board }}
 
     steps:
+      - name: Increase build space
+        run: |
+          echo "Before cleanup"
+          df -H
+          rm -rf /usr/share/dotnet/*
+          rm -rf /usr/local/lib/android/*
+          rm -rf /opt/ghc/*
+          echo "After cleanup"
+          df -H
       - name: Check out the repo
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR adds the same modifications to the CI script as https://github.com/antmicro/alkali-csd-projects/pull/18 so that it won't run out of disk space while building buildroot.