### PR TITLE
Makefile: fixup docker access privs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,7 @@ docker/clean:
 enter: ## enter the development docker image
 	docker run \
 		--rm \
+		--privileged \
 		-v $(PWD):$(PWD) \
 		-v /etc/passwd:/etc/passwd \
 		-v /etc/group:/etc/group \


### PR DESCRIPTION
I was running into `permission denied` errors when executing basic cmds in the container. The `--privileged` flag gives all capabilities to the container, and it also lifts all the limitations enforced by the device cgroup controller. Which helps with that.

Similar to https://github.com/antmicro/alkali-csd-hw/pull/5/commits/c816153af80f587c4d5d1ad9cf103c11daad53e1